### PR TITLE
Update call to accuracy

### DIFF
--- a/courses/dl1/lesson1-rxt50.ipynb
+++ b/courses/dl1/lesson1-rxt50.ipynb
@@ -218,7 +218,7 @@
     "log_preds,y = learn.TTA()\n",
     "probs = np.mean(np.exp(log_preds),0)\n",
     "\n",
-    "accuracy(probs,y)"
+    "accuracy_np(probs,y)"
    ]
   },
   {


### PR DESCRIPTION
Probably this in an API change in torch, but accuracy expects a Tensor, not an Numpy array. This method is the correct one now.